### PR TITLE
Feature/default cell size

### DIFF
--- a/KHDataBinding/KHDataBinding.h
+++ b/KHDataBinding/KHDataBinding.h
@@ -191,6 +191,8 @@
 - (void)setCellHeight:(float)cellHeight model:(id _Nonnull)model;
 - (void)setCellHeight:(float)cellHeight models:(NSArray* _Nonnull)models;
 
+- (void)setDefaultCellHeight:(CGFloat)cellHeight forModelClass:(Class _Nonnull)modalClass;
+
 //  設定 header title
 - (void)setHeaderTitle:(NSString * _Nonnull)headerTitle atSection:(NSUInteger)section;
 
@@ -255,6 +257,7 @@
 - (void)setCellSize:(CGSize)cellSize model:(id _Nonnull)model;
 - (void)setCellSize:(CGSize)cellSize models:(NSArray* _Nonnull)models;
 
+- (void)setDefaultCellSize:(CGSize)cellSize forModelClass:(Class _Nonnull)modelClass;
 
 - (void)registerReusableView:(Class _Nonnull)reusableViewClass;
 - (void)registerReusableView:(Class _Nonnull)reusableViewClass size:(CGSize)size;

--- a/readme.md
+++ b/readme.md
@@ -219,6 +219,15 @@ NSMutableArray<UserModel*> *userList = [dataBinder createBindArray];
 ```
 
 ---
+給定  cell height 或是 cell size 預設值
+---
+
+在 KHDataBinding 裡面，當您不希望 KHDataBinding 讀取 xib size 來自動幫您決定 cell size 時，可以使用 `setDefaultCellHeight:forModelClass:` or `setDefaultCellSize:forModelClass:` 來設定 cell 的預設值，而在 render 後想要改變 cell size 再使用  `setCellHeight:model:` 來動態調整 cell size。
+```objc
+[dataBinder setDefaultCellHeight:60 forModelClass:[UserModel class]];
+```
+
+---
 調整  cell height 或是 cell size
 ---
 


### PR DESCRIPTION
新增 `setDefaultCellHeight:forModelClass:` & `setDefaultCellSize:forModelClass:` 來設定 cell size 初始值。

如果在原先沒有提供初始值的流程下，KHDataBinding 依照 xib 設定來 render cell 有可能會因為螢幕尺寸不同而與預期 layout mismatch 的情形，在這種情況下使用 `setCellHeight:model:` or `setCellSize:model:` 來改變 cell 的大小會造成使用者體驗不佳，所以在這邊提供一個 method 來設定初始值。